### PR TITLE
Update server-id in release.yml to use 'central' for Maven deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         java-version: 8
         distribution: 'adopt'
-        server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+        server-id: central # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: MAVEN_USERNAME # env variable for username in deploy
         server-password: MAVEN_PASSWORD # env variable for token in deploy
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import


### PR DESCRIPTION
This pull request makes a minor configuration update to the Maven deployment step in the GitHub Actions workflow. The change updates the server-id value from ossrh to central, which affects where the artifacts are published.

Changed the server-id in .github/workflows/release.yml from ossrh to central for Maven deployment.