### PR TITLE
update snapshot-repository in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,12 +105,12 @@
     </dependencies>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/</url>
         </repository>
     </distributionManagement>
     <build>
@@ -196,15 +196,12 @@
                 <version>3.0.0</version>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <!-- set to 'false' if you want to manually inspect the repository before releasing -->
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This pull request updates the Maven publishing configuration in the `pom.xml` file to migrate from the old Sonatype OSSRH repository and plugin to the new Sonatype Central repository and publishing plugin. These changes ensure that artifacts are published using the latest infrastructure and tools.

Repository migration:

* Updated the `distributionManagement` section to use the new Sonatype Central repository URLs and changed repository IDs from `ossrh` to `central`.

Publishing plugin update:

* Replaced the `nexus-staging-maven-plugin` with the new `central-publishing-maven-plugin`, updated the group and artifact IDs, and changed the configuration to use `publishingServerId` with the value `central`.