### PR TITLE
fix: merge .percy.yml config options with snapshot options for serializeDOM

### DIFF
--- a/src/main/java/io/percy/playwright/Percy.java
+++ b/src/main/java/io/percy/playwright/Percy.java
@@ -316,17 +316,19 @@ public class Percy {
 
         Object domSnapshot = null;
 
-        // Merge .percy.yml config options with snapshot options (snapshot options take priority)
-        Map<String, Object> mergedOptions = new HashMap<>();
+        // Deep-merge .percy.yml config options with snapshot options. Nested
+        // objects merge recursively, per-call options win at the leaves,
+        // arrays/scalars replace wholesale, and per-call null values do not
+        // clobber a real value coming from .percy.yml config.
+        Map<String, Object> baseConfig = new HashMap<>();
         if (cliConfig != null && cliConfig.has("snapshot") && !cliConfig.isNull("snapshot")) {
             JSONObject snapshotConfig = cliConfig.getJSONObject("snapshot");
-            for (String key : snapshotConfig.keySet()) {
-                mergedOptions.put(key, snapshotConfig.get(key));
+            Object converted = jsonToJava(snapshotConfig);
+            if (converted instanceof Map) {
+                baseConfig = castToStringMap((Map<?, ?>) converted);
             }
         }
-        if (options != null) {
-            mergedOptions.putAll(options);
-        }
+        Map<String, Object> mergedOptions = deepMerge(baseConfig, options);
 
         try {
             String percyDomScript = fetchPercyDOM();
@@ -351,6 +353,76 @@ public class Percy {
         }
 
         return postSnapshot(domSnapshot, name, page.url(), options);
+    }
+
+    /**
+     * Recursively converts org.json structures into plain Java collections so
+     * they can be deep-merged. JSONObject -> HashMap, JSONArray -> ArrayList,
+     * JSONObject.NULL -> null, everything else passes through unchanged.
+     */
+    static Object jsonToJava(Object value) {
+        if (value == null || value == JSONObject.NULL) {
+            return null;
+        }
+        if (value instanceof JSONObject) {
+            JSONObject obj = (JSONObject) value;
+            Map<String, Object> map = new HashMap<>();
+            for (String key : obj.keySet()) {
+                map.put(key, jsonToJava(obj.get(key)));
+            }
+            return map;
+        }
+        if (value instanceof JSONArray) {
+            JSONArray arr = (JSONArray) value;
+            List<Object> list = new ArrayList<>();
+            for (int i = 0; i < arr.length(); i++) {
+                list.add(jsonToJava(arr.get(i)));
+            }
+            return list;
+        }
+        return value;
+    }
+
+    /**
+     * Deep-merges {@code override} onto {@code base}. When both sides hold a
+     * Map for the same key, they merge recursively; otherwise the override wins
+     * at the leaf. Arrays and scalars replace wholesale. Null override values
+     * are skipped so unset per-call params do not clobber config values.
+     */
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> deepMerge(Map<String, Object> base, Map<String, Object> override) {
+        Map<String, Object> result = new HashMap<>();
+        if (base != null) {
+            result.putAll(base);
+        }
+        if (override == null) {
+            return result;
+        }
+        for (Map.Entry<String, Object> entry : override.entrySet()) {
+            String key = entry.getKey();
+            Object overrideValue = entry.getValue();
+            // A null override (e.g. unset positional param) must not clobber config.
+            if (overrideValue == null) {
+                continue;
+            }
+            Object baseValue = result.get(key);
+            if (baseValue instanceof Map && overrideValue instanceof Map) {
+                result.put(key, deepMerge(
+                        castToStringMap((Map<?, ?>) baseValue),
+                        castToStringMap((Map<?, ?>) overrideValue)));
+            } else {
+                result.put(key, overrideValue);
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, Object> castToStringMap(Map<?, ?> map) {
+        Map<String, Object> result = new HashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            result.put(String.valueOf(entry.getKey()), entry.getValue());
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/io/percy/playwright/Percy.java
+++ b/src/main/java/io/percy/playwright/Percy.java
@@ -299,6 +299,19 @@ public class Percy {
         if ("automate".equals(sessionType)) { throw new RuntimeException("Invalid function call - snapshot(). Please use screenshot() function while using Percy with Automate. For more information on usage of PercyScreenshot, refer https://www.browserstack.com/docs/percy/integrate/functional-and-visual"); }
 
         Object domSnapshot = null;
+
+        // Merge .percy.yml config options with snapshot options (snapshot options take priority)
+        Map<String, Object> mergedOptions = new HashMap<>();
+        if (cliConfig != null && cliConfig.has("snapshot") && !cliConfig.isNull("snapshot")) {
+            JSONObject snapshotConfig = cliConfig.getJSONObject("snapshot");
+            for (String key : snapshotConfig.keySet()) {
+                mergedOptions.put(key, snapshotConfig.get(key));
+            }
+        }
+        if (options != null) {
+            mergedOptions.putAll(options);
+        }
+
         try {
             String percyDomScript = fetchPercyDOM();
             page.evaluate(percyDomScript);
@@ -310,10 +323,10 @@ public class Percy {
                 log("Cookie collection failed: " + e.getMessage(), "debug");
             }
 
-            if (isCaptureResponsiveDOM(options)) {
-                domSnapshot = captureResponsiveDom(cookies, percyDomScript, options);
+            if (isCaptureResponsiveDOM(mergedOptions)) {
+                domSnapshot = captureResponsiveDom(cookies, percyDomScript, mergedOptions);
             } else {
-                domSnapshot = getSerializedDOM(cookies, percyDomScript, options);
+                domSnapshot = getSerializedDOM(cookies, percyDomScript, mergedOptions);
             }
         } catch (Exception e) {
             log("Snapshot capture failed: " + e.getMessage());

--- a/src/test/java/io/percy/playwright/SDKTest.java
+++ b/src/test/java/io/percy/playwright/SDKTest.java
@@ -664,4 +664,40 @@ public class SDKTest {
         assertEquals("<html></html>", result.get("html"));
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void deepMergesConfigWithPerCallOptions() {
+        // Simulate cliConfig.snapshot with a nested discovery block.
+        JSONObject snapshotConfig = new JSONObject();
+        JSONObject discovery = new JSONObject();
+        discovery.put("networkIdleTimeout", 50);
+        discovery.put("disableCache", false);
+        snapshotConfig.put("discovery", discovery);
+        snapshotConfig.put("widths", new org.json.JSONArray(Arrays.asList(375, 1280)));
+
+        Object base = Percy.jsonToJava(snapshotConfig);
+        assertTrue(base instanceof Map);
+
+        // Per-call options: override only one nested leaf + a null that must not clobber.
+        Map<String, Object> perCallDiscovery = new HashMap<>();
+        perCallDiscovery.put("disableCache", true);
+        Map<String, Object> options = new HashMap<>();
+        options.put("discovery", perCallDiscovery);
+        options.put("scope", null); // null per-call value must be skipped
+
+        Map<String, Object> merged = Percy.deepMerge((Map<String, Object>) base, options);
+
+        // Nested discovery is deep-merged: per-call wins at disableCache, config kept for networkIdleTimeout.
+        Map<String, Object> mergedDiscovery = (Map<String, Object>) merged.get("discovery");
+        assertEquals(50, mergedDiscovery.get("networkIdleTimeout"));
+        assertEquals(true, mergedDiscovery.get("disableCache"));
+
+        // Arrays/scalars from config survive when not overridden.
+        assertTrue(merged.get("widths") instanceof List);
+        assertEquals(Arrays.asList(375, 1280), merged.get("widths"));
+
+        // Null per-call value did not clobber and did not add the key.
+        assertFalse(merged.containsKey("scope"));
+    }
+
 }

--- a/src/test/java/io/percy/playwright/SDKTest.java
+++ b/src/test/java/io/percy/playwright/SDKTest.java
@@ -554,6 +554,90 @@ public class SDKTest {
         assertNull(result.get("readiness_diagnostics"));
     }
 
+    // -------------------------------------------------------------------------
+    // .percy.yml config <-> per-snapshot merge precedence
+    // -------------------------------------------------------------------------
+
+    /**
+     * cliConfig.snapshot supplies a config-only key (enableJavaScript) and a
+     * percyCSS value. The per-snapshot call also supplies percyCSS. The merged
+     * options handed to PercyDOM.serialize(...) must:
+     *   - retain the config-only key (enableJavaScript = true), and
+     *   - let the per-snapshot percyCSS ("FROM_CALL") win over the config value.
+     */
+    @Test
+    @Order(93)
+    @SuppressWarnings("unchecked")
+    public void perSnapshotOptionsOverrideConfigInSerializedOptions() throws Exception {
+        Page mockPage = Mockito.mock(Page.class);
+        BrowserContext mockContext = Mockito.mock(BrowserContext.class);
+
+        // Serialize path: single-arg evaluate(PercyDOM.serialize({...})) returns the DOM
+        Map<String, Object> domMap = new HashMap<>();
+        domMap.put("html", "<html></html>");
+        when(mockPage.evaluate(anyString())).thenReturn(domMap);
+        when(mockPage.url()).thenReturn("http://example.com");
+        when(mockPage.frames()).thenReturn(new ArrayList<>());
+        when(mockPage.context()).thenReturn(mockContext);
+        when(mockContext.cookies()).thenReturn(new ArrayList<>());
+
+        Percy percyInstance = spy(new Percy(mockPage));
+        percyInstance.sessionType = "web";
+
+        // Force Percy enabled and pre-seed the cached dom.js so no HTTP calls fire
+        setPrivateField(percyInstance, "isPercyEnabled", true);
+        setPrivateField(percyInstance, "domJs", "// percy dom script");
+
+        // Don't actually POST anything back to the CLI
+        doReturn(null).when(percyInstance).request(anyString(), any(JSONObject.class), anyString());
+
+        // Inject .percy.yml config: config-only enableJavaScript + percyCSS from config
+        JSONObject snapshotConfig = new JSONObject();
+        snapshotConfig.put("enableJavaScript", true);
+        snapshotConfig.put("percyCSS", "FROM_CONFIG");
+        JSONObject config = new JSONObject();
+        config.put("snapshot", snapshotConfig);
+        percyInstance.cliConfig = config;
+
+        // Per-call options override percyCSS only
+        Map<String, Object> options = new HashMap<>();
+        options.put("percyCSS", "FROM_CALL");
+
+        percyInstance.snapshot("merge-precedence", options);
+
+        // Capture the JS string passed to the single-arg serialize evaluate
+        ArgumentCaptor<String> jsCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockPage, atLeastOnce()).evaluate(jsCaptor.capture());
+
+        String serializeJs = null;
+        for (String js : jsCaptor.getAllValues()) {
+            if (js != null && js.contains("PercyDOM.serialize(")) {
+                serializeJs = js;
+                break;
+            }
+        }
+        assertNotNull(serializeJs, "PercyDOM.serialize(...) call should have been made");
+
+        // Parse the JSON argument out of PercyDOM.serialize({...})
+        int start = serializeJs.indexOf('{');
+        int end = serializeJs.lastIndexOf('}');
+        assertTrue(start >= 0 && end > start, "serialize JS should contain a JSON object argument");
+        JSONObject serializedOptions = new JSONObject(serializeJs.substring(start, end + 1));
+
+        // Config-only key survives the merge
+        assertTrue(serializedOptions.has("enableJavaScript"), "config-only enableJavaScript should be merged in");
+        assertTrue(serializedOptions.getBoolean("enableJavaScript"), "enableJavaScript should be true from config");
+        // Per-call value wins over config value
+        assertEquals("FROM_CALL", serializedOptions.getString("percyCSS"),
+                "per-snapshot percyCSS must override the .percy.yml config value");
+    }
+
+    private static void setPrivateField(Object target, String name, Object value) throws Exception {
+        java.lang.reflect.Field field = Percy.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
     @Test
     @Order(92)
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- Config options from `.percy.yml` were not being passed to `PercyDOM.serialize()`
- Only per-snapshot options were used for DOM serialization
- Now merges `cliConfig.snapshot` into options Map before calling `getSerializedDOM()`, with per-snapshot options taking priority

## Test plan
- [ ] Existing tests pass
- [ ] Verify `.percy.yml` config options are applied during DOM serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)