### PR TITLE
🔖 Release 1.2.1-beta.0 (PER-7348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add percy-playwright-java to your project dependencies. If you're using Maven:
 <dependency>
   <groupId>io.percy</groupId>
   <artifactId>percy-playwright-java</artifactId>
-  <version>1.0.2</version>
+  <version>1.2.1-beta.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.percy</groupId>
     <artifactId>percy-playwright-java</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.1-beta.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -33,7 +33,7 @@
         <connection>scm:git:git://github.com/percy/percy-playwright-java.git</connection>
         <developerConnection>scm:git:https://github.com/percy/percy-playwright-java.git</developerConnection>
         <url>https://github.com/percy/percy-playwright-java/tree/master</url>
-        <tag>v1.0.2</tag>
+        <tag>v1.2.1-beta.0</tag>
     </scm>
 
     <properties>

--- a/src/main/java/io/percy/playwright/Environment.java
+++ b/src/main/java/io/percy/playwright/Environment.java
@@ -6,7 +6,7 @@ import com.microsoft.playwright.Playwright;
  * Package-private class to compute Environment information.
  */
 class Environment {
-    private final static String SDK_VERSION = "1.0.2";
+    private final static String SDK_VERSION = "1.2.1-beta.0";
     private final static String SDK_NAME = "percy-playwright-java";
 
     private String clientInfoOverride;


### PR DESCRIPTION
Beta release shipping the **PER-7348 readiness gate** (`waitForReady` before serialize), merged in #31.

### Version bump → `1.2.1-beta.0`
- `pom.xml` — `<version>` and `<scm><tag>`
- `src/main/java/io/percy/playwright/Environment.java` — `SDK_VERSION`
- `README.md` — Maven install snippet

Ships with `@percy/cli@^1.31.15-beta.0` (readiness-capable CLI). Follows the same beta-release flow used for the other PER-7348 SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)