### PR TITLE
release v1.2.1-beta.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.percy</groupId>
     <artifactId>percy-playwright-java</artifactId>
-    <version>1.2.1-beta.0</version>
+    <version>1.2.1-beta.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/percy/playwright/Environment.java
+++ b/src/main/java/io/percy/playwright/Environment.java
@@ -6,7 +6,7 @@ import com.microsoft.playwright.Playwright;
  * Package-private class to compute Environment information.
  */
 class Environment {
-    private final static String SDK_VERSION = "1.2.1-beta.0";
+    private final static String SDK_VERSION = "1.2.1-beta.1";
     private final static String SDK_NAME = "percy-playwright-java";
 
     private String clientInfoOverride;


### PR DESCRIPTION
Bumps the SDK to the next beta (`1.2.1-beta.0` → `1.2.1-beta.1`) for a beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)